### PR TITLE
properly get client ip if behind proxy

### DIFF
--- a/custom_components/reflex_magic_link_auth/state.py
+++ b/custom_components/reflex_magic_link_auth/state.py
@@ -140,7 +140,7 @@ class MagicLinkAuthState(MagicLinkBaseState):
                 expiration=(
                     datetime.datetime.now(datetime.timezone.utc) + expiration_delta
                 ),
-                client_ip=self._get_client_ip(),    
+                client_ip=self._get_client_ip(),
                 recent_attempts=recent_attempts + 1,
             )
             session.add(record)


### PR DESCRIPTION
The original code tried to get x_forwarded_for from self.router.headers, which does not exist.
The correct name for the header set by proxies is x-forwarded-for and it's in raw headers.
As it can be a list, it must be split (take first element, if there are multiple).
If I got something wrong an I need to add a special rx config setting to populate x_forwarded_for in self.router.headers, please let me know.